### PR TITLE
auth: Set auth.Claim to context instead of auth.User

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -53,7 +53,7 @@ func UserFromContext(ctx context.Context) (*Claims, bool) {
 	return claim, ok
 }
 
-func (c *Config) WithAuth(next http.Handler) http.Handler {
+func (c *Config) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claim, err := authenticate(c, r)
 		if err != nil {

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -68,7 +68,7 @@ func testHandler(c *auth.Config, r *http.Request, h http.Handler) *httptest.Resp
 		Handle("/", h).
 		Methods("GET")
 
-	c.WithAuth(router).ServeHTTP(recorder, r)
+	c.Middleware(router).ServeHTTP(recorder, r)
 
 	return recorder
 }

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -41,10 +41,11 @@ func testConfig(t *testing.T, now time.Time, userId, redisId string, client util
 
 func testingHandler(t *testing.T, expected *auth.User) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, ok := r.Context().Value("user").(*auth.User)
+		claim, ok := auth.UserFromContext(r.Context())
 
 		expect.True(t, ok)
-		expect.Equal(t, expected, user)
+		expect.Equal(t, expected.Id, claim.UserId)
+		expect.Equal(t, expected.Name, claim.Name)
 	})
 }
 
@@ -114,7 +115,6 @@ func TestAuthHandler(t *testing.T) {
 	request.Header.Add("Authorization", "Bearer "+token)
 	r = testHandler(config, request, testingHandler(t, user))
 	expecthttp.Ok(t, r)
-	expecthttp.Header(t, "Bissy-Token", token, r.Header())
 }
 
 func TestTokenHandler(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 	router.Use(hnygorilla.Middleware)
 	router.HandleFunc("/", homeHandler)
 	router.HandleFunc("/ping", ping.Handler)
-	router.Handle("/authping", authConfig.WithAuth(http.HandlerFunc(ping.Handler)))
+	router.Handle("/authping", authConfig.Middleware(http.HandlerFunc(ping.Handler)))
 
 	authMux := router.PathPrefix("/auth").Subrouter()
 	authConfig.SetupHandlers(authMux)
@@ -127,7 +127,7 @@ func main() {
 		Clock:           clock,
 	}
 
-	querycacheMux.Use(authConfig.WithAuth)
+	querycacheMux.Use(authConfig.Middleware)
 	queryCacheConfig.SetupHandlers(querycacheMux)
 
 	handler := handlers.LoggingHandler(os.Stdout, hnynethttp.WrapHandler(router))


### PR DESCRIPTION
Remove need for DB call during auth, rely on the token only.
Pass the auth.Claim into the context and expose auth.UserFromContext as
a helper to retrieve the user.