### PR TITLE
querycache: add UserID to Datasource & Query

### DIFF
--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -38,13 +38,13 @@ func (c *Config) token(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	user, err := c.userStore.Get(userID)
-	if err != nil || userID == "" {
+	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: fmt.Errorf("bad user id"), Status: http.StatusBadRequest}
 	}
 
 	token, err := c.SignedToken(user)
-	if err != nil || userID == "" {
+	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: fmt.Errorf("error signing token"), Status: http.StatusInternalServerError}
 	}

--- a/migrations/20200617223929_add_user_id_to_datasource.down.sql
+++ b/migrations/20200617223929_add_user_id_to_datasource.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE querycache_datasources
+DROP COLUMN IF EXISTS user_id;

--- a/migrations/20200617223929_add_user_id_to_datasource.up.sql
+++ b/migrations/20200617223929_add_user_id_to_datasource.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE querycache_datasources
+ADD COLUMN IF NOT EXISTS user_id uuid NOT NULL;

--- a/migrations/20200617233518_add_user_id_to_query.down.sql
+++ b/migrations/20200617233518_add_user_id_to_query.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE querycache_queries
+DROP COLUMN IF EXISTS user_id uuid;

--- a/migrations/20200617233518_add_user_id_to_query.up.sql
+++ b/migrations/20200617233518_add_user_id_to_query.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE querycache_queries
+ADD COLUMN IF NOT EXISTS user_id uuid NOT NULL;

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -53,7 +53,7 @@ func (c *Config) datasourceGet(claims *auth.Claims, id string, w http.ResponseWr
 }
 
 func (c *Config) datasourceDelete(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
-	datasource, err := c.DatasourceStore.Delete(id)
+	datasource, err := c.DatasourceStore.Delete(claims.UserID, id)
 	if err != nil {
 		return err
 	}

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cga1123/bissy-api/auth"
 	"github.com/cga1123/bissy-api/handlerutils"
 	"github.com/cga1123/bissy-api/utils"
 )
 
-func (c *Config) datasourcesList(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) datasourcesList(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -25,7 +26,7 @@ func (c *Config) datasourcesList(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(datasources)
 }
 
-func (c *Config) datasourcesCreate(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) datasourcesCreate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	var createDatasource CreateDatasource
@@ -49,7 +50,7 @@ func (c *Config) datasourcesCreate(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
-func (c *Config) datasourceGet(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) datasourceGet(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -67,7 +68,7 @@ func (c *Config) datasourceGet(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(datasource)
 }
 
-func (c *Config) datasourceDelete(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) datasourceDelete(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -85,7 +86,7 @@ func (c *Config) datasourceDelete(w http.ResponseWriter, r *http.Request) error 
 	return json.NewEncoder(w).Encode(datasource)
 }
 
-func (c *Config) datasourceUpdate(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) datasourceUpdate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -34,7 +34,7 @@ func (c *Config) datasourcesCreate(claims *auth.Claims, w http.ResponseWriter, r
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	datasource, err := c.DatasourceStore.Create(&createDatasource)
+	datasource, err := c.DatasourceStore.Create(claims.UserID, &createDatasource)
 	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: err, Status: http.StatusUnprocessableEntity}

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -68,7 +68,7 @@ func (c *Config) datasourceUpdate(claims *auth.Claims, id string, w http.Respons
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	datasource, err := c.DatasourceStore.Update(id, &updateDatasource)
+	datasource, err := c.DatasourceStore.Update(claims.UserID, id, &updateDatasource)
 	if err != nil {
 		return err
 	}

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -2,7 +2,6 @@ package querycache
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/cga1123/bissy-api/auth"
@@ -50,16 +49,7 @@ func (c *Config) datasourcesCreate(claims *auth.Claims, w http.ResponseWriter, r
 	return nil
 }
 
-func (c *Config) datasourceGet(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) datasourceGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	datasource, err := c.DatasourceStore.Get(id)
 	if err != nil {
 		return err
@@ -68,16 +58,7 @@ func (c *Config) datasourceGet(claims *auth.Claims, w http.ResponseWriter, r *ht
 	return json.NewEncoder(w).Encode(datasource)
 }
 
-func (c *Config) datasourceDelete(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) datasourceDelete(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	datasource, err := c.DatasourceStore.Delete(id)
 	if err != nil {
 		return err
@@ -86,16 +67,7 @@ func (c *Config) datasourceDelete(claims *auth.Claims, w http.ResponseWriter, r 
 	return json.NewEncoder(w).Encode(datasource)
 }
 
-func (c *Config) datasourceUpdate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) datasourceUpdate(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	var updateDatasource UpdateDatasource
 	if err := utils.ParseJSONBody(r.Body, &updateDatasource); err != nil {
 		return &handlerutils.HandlerError{

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -40,13 +40,7 @@ func (c *Config) datasourcesCreate(claims *auth.Claims, w http.ResponseWriter, r
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	err = json.NewEncoder(w).Encode(datasource)
-	if err != nil {
-		return &handlerutils.HandlerError{
-			Err: err, Status: http.StatusInternalServerError}
-	}
-
-	return nil
+	return json.NewEncoder(w).Encode(datasource)
 }
 
 func (c *Config) datasourceGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -16,7 +16,7 @@ func (c *Config) datasourcesList(claims *auth.Claims, w http.ResponseWriter, r *
 	page := params.MaybeInt("page", 1)
 	per := params.MaybeInt("per", 25)
 
-	datasources, err := c.DatasourceStore.List(page, per)
+	datasources, err := c.DatasourceStore.List(claims.UserID, page, per)
 	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: err, Status: http.StatusInternalServerError}

--- a/querycache/datasource_handlers.go
+++ b/querycache/datasource_handlers.go
@@ -44,7 +44,7 @@ func (c *Config) datasourcesCreate(claims *auth.Claims, w http.ResponseWriter, r
 }
 
 func (c *Config) datasourceGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
-	datasource, err := c.DatasourceStore.Get(id)
+	datasource, err := c.DatasourceStore.Get(claims.UserID, id)
 	if err != nil {
 		return err
 	}

--- a/querycache/datasource_handlers_test.go
+++ b/querycache/datasource_handlers_test.go
@@ -29,8 +29,10 @@ func TestDatasourceCreate(t *testing.T) {
 	request, err := http.NewRequest("POST", "/datasources", json)
 	expect.Ok(t, err)
 
+	claims := testClaims()
 	expected := &querycache.Datasource{
 		ID:        id,
+		UserID:    claims.UserID,
 		Name:      "test datasource",
 		Type:      "postgres",
 		Options:   "",
@@ -38,7 +40,6 @@ func TestDatasourceCreate(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.JSONBody(t, expected, response.Body)

--- a/querycache/datasource_handlers_test.go
+++ b/querycache/datasource_handlers_test.go
@@ -44,7 +44,7 @@ func TestDatasourceCreate(t *testing.T) {
 	expecthttp.Ok(t, response)
 	expecthttp.JSONBody(t, expected, response.Body)
 
-	actual, err := config.DatasourceStore.Get(id)
+	actual, err := config.DatasourceStore.Get(claims.UserID, id)
 
 	expect.Ok(t, err)
 	expect.Equal(t, expected, actual)
@@ -134,7 +134,7 @@ func TestDatasourceUpdate(t *testing.T) {
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasource, response.Body)
 
-	datasource, err = config.DatasourceStore.Get(id)
+	datasource, err = config.DatasourceStore.Get(claims.UserID, id)
 	expect.Ok(t, err)
 
 	expect.Equal(t, "test", datasource.Name)

--- a/querycache/datasource_handlers_test.go
+++ b/querycache/datasource_handlers_test.go
@@ -38,7 +38,8 @@ func TestDatasourceCreate(t *testing.T) {
 		UpdatedAt: now,
 	}
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.JSONBody(t, expected, response.Body)
 
@@ -65,7 +66,8 @@ func TestDatasourceGet(t *testing.T) {
 	request, err := http.NewRequest("GET", "/datasources/"+id, nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasource, response.Body)
@@ -88,7 +90,8 @@ func TestDatasourceDelete(t *testing.T) {
 	request, err := http.NewRequest("DELETE", "/datasources/"+id, nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasource, response.Body)
@@ -124,7 +127,8 @@ func TestDatasourceUpdate(t *testing.T) {
 	datasource.Type = "snowflake"
 	datasource.Options = ""
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasource, response.Body)
@@ -159,7 +163,8 @@ func TestDatasourceList(t *testing.T) {
 	request, err := http.NewRequest("GET", "/datasources", nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasources[:25], response.Body)
@@ -168,7 +173,7 @@ func TestDatasourceList(t *testing.T) {
 	request, err = http.NewRequest("GET", "/datasources?page=2&per=5", nil)
 	expect.Ok(t, err)
 
-	response = testHandler(config, request)
+	response = testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasources[5:10], response.Body)

--- a/querycache/datasource_handlers_test.go
+++ b/querycache/datasource_handlers_test.go
@@ -97,7 +97,7 @@ func TestDatasourceDelete(t *testing.T) {
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, datasource, response.Body)
 
-	datasources, err := config.DatasourceStore.List(1, 1)
+	datasources, err := config.DatasourceStore.List(claims.UserID, 1, 1)
 	expect.Ok(t, err)
 	expect.Equal(t, []*querycache.Datasource{}, datasources)
 }

--- a/querycache/datasource_handlers_test.go
+++ b/querycache/datasource_handlers_test.go
@@ -56,7 +56,8 @@ func TestDatasourceGet(t *testing.T) {
 	defer teardown()
 
 	_, id, config := testConfig(db)
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{
+	claims := testClaims()
+	datasource, err := config.DatasourceStore.Create(claims.UserID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -66,7 +67,6 @@ func TestDatasourceGet(t *testing.T) {
 	request, err := http.NewRequest("GET", "/datasources/"+id, nil)
 	expect.Ok(t, err)
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
@@ -80,7 +80,8 @@ func TestDatasourceDelete(t *testing.T) {
 	defer teardown()
 
 	_, id, config := testConfig(db)
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{
+	claims := testClaims()
+	datasource, err := config.DatasourceStore.Create(claims.UserID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -90,7 +91,6 @@ func TestDatasourceDelete(t *testing.T) {
 	request, err := http.NewRequest("DELETE", "/datasources/"+id, nil)
 	expect.Ok(t, err)
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
@@ -108,7 +108,8 @@ func TestDatasourceUpdate(t *testing.T) {
 	defer teardown()
 
 	_, id, config := testConfig(db)
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{
+	claims := testClaims()
+	datasource, err := config.DatasourceStore.Create(claims.UserID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable"})
@@ -127,7 +128,6 @@ func TestDatasourceUpdate(t *testing.T) {
 	datasource.Type = "snowflake"
 	datasource.Options = ""
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
@@ -149,11 +149,12 @@ func TestDatasourceList(t *testing.T) {
 	db, teardown := utils.TestDB(t)
 	defer teardown()
 
+	claims := testClaims()
 	config := &querycache.Config{
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, &utils.RealClock{}, &utils.UUIDGenerator{})}
 
 	for i := 0; i < 30; i++ {
-		datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{
+		datasource, err := config.DatasourceStore.Create(claims.UserID, &querycache.CreateDatasource{
 			Name: fmt.Sprintf("Name %v", i)})
 
 		expect.Ok(t, err)
@@ -163,7 +164,6 @@ func TestDatasourceList(t *testing.T) {
 	request, err := http.NewRequest("GET", "/datasources", nil)
 	expect.Ok(t, err)
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -20,7 +20,7 @@ func NewSQLDatasourceStore(db *hnysqlx.DB, clock utils.Clock, generator utils.ID
 }
 
 // Create creates and persists a new Datasource to the Store
-func (s *SQLDatasourceStore) Create(ca *CreateDatasource) (*Datasource, error) {
+func (s *SQLDatasourceStore) Create(userID string, ca *CreateDatasource) (*Datasource, error) {
 	now := s.clock.Now()
 	id := s.idGenerator.Generate()
 

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -25,12 +25,12 @@ func (s *SQLDatasourceStore) Create(userID string, ca *CreateDatasource) (*Datas
 	id := s.idGenerator.Generate()
 
 	query := `
-		INSERT INTO querycache_datasources (id, name, type, options, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO querycache_datasources (id, user_id, name, type, options, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING *`
 
 	var datasource Datasource
-	if err := s.db.Get(&datasource, query, id, ca.Name, ca.Type, ca.Options, now, now); err != nil {
+	if err := s.db.Get(&datasource, query, id, userID, ca.Name, ca.Type, ca.Options, now, now); err != nil {
 		return nil, err
 	}
 

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -51,12 +51,12 @@ func (s *SQLDatasourceStore) Get(userID, id string) (*Datasource, error) {
 }
 
 // Delete removes the Datasource with given id from the Store
-func (s *SQLDatasourceStore) Delete(id string) (*Datasource, error) {
+func (s *SQLDatasourceStore) Delete(userID, id string) (*Datasource, error) {
 	var datasource Datasource
 
-	query := "DELETE FROM querycache_datasources WHERE id = $1 RETURNING *"
+	query := "DELETE FROM querycache_datasources WHERE id = $1 AND user_id = $2 RETURNING *"
 
-	if err := s.db.Get(&datasource, query, id); err != nil {
+	if err := s.db.Get(&datasource, query, id, userID); err != nil {
 		return nil, err
 	}
 

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -41,9 +41,9 @@ func (s *SQLDatasourceStore) Create(userID string, ca *CreateDatasource) (*Datas
 func (s *SQLDatasourceStore) Get(userID, id string) (*Datasource, error) {
 	var datasource Datasource
 
-	query := "SELECT * FROM querycache_datasources WHERE id = $1"
+	query := "SELECT * FROM querycache_datasources WHERE id = $1 AND user_id = $2"
 
-	if err := s.db.Get(&datasource, query, id); err != nil {
+	if err := s.db.Get(&datasource, query, id, userID); err != nil {
 		return nil, err
 	}
 

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -38,7 +38,7 @@ func (s *SQLDatasourceStore) Create(userID string, ca *CreateDatasource) (*Datas
 }
 
 // Get returns the Datasource with associated id from the store
-func (s *SQLDatasourceStore) Get(id string) (*Datasource, error) {
+func (s *SQLDatasourceStore) Get(userID, id string) (*Datasource, error) {
 	var datasource Datasource
 
 	query := "SELECT * FROM querycache_datasources WHERE id = $1"

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -82,18 +82,20 @@ func (s *SQLDatasourceStore) List(page, per int) ([]*Datasource, error) {
 }
 
 // Update updates the Datasource with associated id from the store
-func (s *SQLDatasourceStore) Update(id string, ua *UpdateDatasource) (*Datasource, error) {
+func (s *SQLDatasourceStore) Update(userID, id string, ua *UpdateDatasource) (*Datasource, error) {
 	var datasource Datasource
 
 	query := `
 		UPDATE querycache_datasources
-		SET name = COALESCE($2, name),
-				type = COALESCE($3, type),
-				options = COALESCE($4, options)
-		WHERE id = $1
+		SET name = COALESCE($3, name),
+				type = COALESCE($4, type),
+				options = COALESCE($5, options)
+		WHERE 1=1
+		AND id = $1
+		AND user_id = $2
 		RETURNING *`
 
-	if err := s.db.Get(&datasource, query, id, ua.Name, ua.Type, ua.Options); err != nil {
+	if err := s.db.Get(&datasource, query, id, userID, ua.Name, ua.Type, ua.Options); err != nil {
 		return nil, err
 	}
 

--- a/querycache/datasource_sql_store.go
+++ b/querycache/datasource_sql_store.go
@@ -64,7 +64,7 @@ func (s *SQLDatasourceStore) Delete(userID, id string) (*Datasource, error) {
 }
 
 // List returns the requests Datasources from the Store, ordered by createdAt
-func (s *SQLDatasourceStore) List(page, per int) ([]*Datasource, error) {
+func (s *SQLDatasourceStore) List(userID string, page, per int) ([]*Datasource, error) {
 	if page < 1 || per < 1 {
 		return nil,
 			fmt.Errorf("page and per must be greater than 0 (page %v) (per %v)",
@@ -73,8 +73,15 @@ func (s *SQLDatasourceStore) List(page, per int) ([]*Datasource, error) {
 
 	datasources := []*Datasource{}
 
-	query := `SELECT * FROM querycache_datasources ORDER BY created_at OFFSET $1 LIMIT $2`
-	if err := s.db.Select(&datasources, query, (page-1)*per, per); err != nil {
+	query := `
+		SELECT *
+		FROM querycache_datasources
+		WHERE user_id = $1
+		ORDER BY created_at
+		OFFSET $2
+		LIMIT $3`
+
+	if err := s.db.Select(&datasources, query, userID, (page-1)*per, per); err != nil {
 		return nil, err
 	}
 

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -34,7 +34,7 @@ type CreateDatasource struct {
 type DatasourceStore interface {
 	Get(string, string) (*Datasource, error)
 	Create(string, *CreateDatasource) (*Datasource, error)
-	List(page int, per int) ([]*Datasource, error)
+	List(string, int, int) ([]*Datasource, error)
 	Delete(string, string) (*Datasource, error)
 	Update(string, string, *UpdateDatasource) (*Datasource, error)
 }

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -36,7 +36,7 @@ type DatasourceStore interface {
 	Create(string, *CreateDatasource) (*Datasource, error)
 	List(page int, per int) ([]*Datasource, error)
 	Delete(string, string) (*Datasource, error)
-	Update(string, *UpdateDatasource) (*Datasource, error)
+	Update(string, string, *UpdateDatasource) (*Datasource, error)
 }
 
 // NewExecutor returns a new SQLExecutor configured against this Datasource

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -32,7 +32,7 @@ type CreateDatasource struct {
 
 // DatasourceStore describes a generic Store for Datasources
 type DatasourceStore interface {
-	Get(string) (*Datasource, error)
+	Get(string, string) (*Datasource, error)
 	Create(string, *CreateDatasource) (*Datasource, error)
 	List(page int, per int) ([]*Datasource, error)
 	Delete(string) (*Datasource, error)

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -32,7 +32,7 @@ type CreateDatasource struct {
 // DatasourceStore describes a generic Store for Datasources
 type DatasourceStore interface {
 	Get(string) (*Datasource, error)
-	Create(*CreateDatasource) (*Datasource, error)
+	Create(string, *CreateDatasource) (*Datasource, error)
 	List(page int, per int) ([]*Datasource, error)
 	Delete(string) (*Datasource, error)
 	Update(string, *UpdateDatasource) (*Datasource, error)

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -35,7 +35,7 @@ type DatasourceStore interface {
 	Get(string, string) (*Datasource, error)
 	Create(string, *CreateDatasource) (*Datasource, error)
 	List(page int, per int) ([]*Datasource, error)
-	Delete(string) (*Datasource, error)
+	Delete(string, string) (*Datasource, error)
 	Update(string, *UpdateDatasource) (*Datasource, error)
 }
 

--- a/querycache/datasource_store.go
+++ b/querycache/datasource_store.go
@@ -8,6 +8,7 @@ import (
 // against
 type Datasource struct {
 	ID        string    `json:"id" db:"id"`
+	UserID    string    `json:"userId" db:"user_id"`
 	Name      string    `json:"name"`
 	Type      string    `json:"type"`
 	Options   string    `json:"options"`

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 func testDatasourceCreate(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {
+	userID := uuid.New().String()
 	expected := &querycache.Datasource{
 		ID:        id,
+		UserID:    userID,
 		Name:      "test datasource",
 		Type:      "postgres",
 		Options:   "sslmode=disable",
@@ -26,7 +28,6 @@ func testDatasourceCreate(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	userID := uuid.New().String()
 	datasource, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
@@ -43,8 +44,10 @@ func testDatasourceCreate(t *testing.T, store querycache.DatasourceStore, id str
 }
 
 func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {
+	userID := uuid.New().String()
 	expected := &querycache.Datasource{
 		ID:        id,
+		UserID:    userID,
 		Name:      "test datasource",
 		Type:      "postgres",
 		Options:   "sslmode=disable",
@@ -52,7 +55,6 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	userID := uuid.New().String()
 	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
@@ -71,8 +73,10 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 }
 
 func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {
+	userID := uuid.New().String()
 	expected := &querycache.Datasource{
 		ID:        id,
+		UserID:    userID,
 		Name:      "test datasource",
 		Type:      "postgres",
 		Options:   "sslmode=disable",
@@ -80,7 +84,6 @@ func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string
 		UpdatedAt: now,
 	}
 
-	userID := uuid.New().String()
 	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
@@ -94,8 +97,10 @@ func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string
 }
 
 func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {
+	userID := uuid.New().String()
 	expected := &querycache.Datasource{
 		ID:        id,
+		UserID:    userID,
 		Name:      "test snowdapter",
 		Type:      "snowflake",
 		Options:   "",
@@ -103,7 +108,6 @@ func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	userID := uuid.New().String()
 	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -26,7 +26,8 @@ func testDatasourceCreate(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	datasource, err := store.Create(&querycache.CreateDatasource{
+	userID := uuid.New().String()
+	datasource, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -51,7 +52,8 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	_, err := store.Create(&querycache.CreateDatasource{
+	userID := uuid.New().String()
+	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -78,7 +80,8 @@ func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string
 		UpdatedAt: now,
 	}
 
-	_, err := store.Create(&querycache.CreateDatasource{
+	userID := uuid.New().String()
+	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -100,7 +103,8 @@ func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id str
 		UpdatedAt: now,
 	}
 
-	_, err := store.Create(&querycache.CreateDatasource{
+	userID := uuid.New().String()
+	_, err := store.Create(userID, &querycache.CreateDatasource{
 		Name:    "test datasource",
 		Type:    "postgres",
 		Options: "sslmode=disable",
@@ -141,10 +145,11 @@ func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id str
 func testDatasourceList(t *testing.T, store querycache.DatasourceStore) {
 	expectedDatasources := []*querycache.Datasource{}
 
+	userID := uuid.New().String()
 	for i := 0; i < 10; i++ {
 		s := fmt.Sprintf("name %v;", i)
 		q := &querycache.CreateDatasource{Name: s}
-		datasource, err := store.Create(q)
+		datasource, err := store.Create(userID, q)
 		expect.Ok(t, err)
 
 		expectedDatasources = append(expectedDatasources, datasource)

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -1,6 +1,7 @@
 package querycache_test
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -94,6 +95,16 @@ func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string
 	datasource, err := store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
+
+	// when not found
+	datasource, err = store.Get(userID, uuid.New().String())
+	expect.Error(t, err)
+	expect.True(t, sql.ErrNoRows == err)
+
+	// when other user
+	datasource, err = store.Get(uuid.New().String(), id)
+	expect.Error(t, err)
+	expect.True(t, sql.ErrNoRows == err)
 }
 
 func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -63,7 +63,13 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 	})
 	expect.Ok(t, err)
 
-	datasource, err := store.Delete(id)
+	// When a different user is trying to delete
+	_, err = store.Delete(uuid.New().String(), id)
+	expect.Error(t, err)
+	expect.True(t, err == sql.ErrNoRows)
+
+	// When the owner is trying to delete
+	datasource, err := store.Delete(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
@@ -71,6 +77,7 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 	expect.Ok(t, err)
 
 	expect.Equal(t, []*querycache.Datasource{}, datasources)
+
 }
 
 func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string, now time.Time) {

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -77,7 +77,7 @@ func testDatasourceDelete(t *testing.T, store querycache.DatasourceStore, id str
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
-	datasources, err := store.List(1, 1)
+	datasources, err := store.List(userID, 1, 1)
 	expect.Ok(t, err)
 
 	expect.Equal(t, []*querycache.Datasource{}, datasources)
@@ -194,29 +194,34 @@ func testDatasourceList(t *testing.T, store querycache.DatasourceStore) {
 		expectedDatasources = append(expectedDatasources, datasource)
 	}
 
-	_, err := store.List(0, 1)
+	_, err := store.List(userID, 0, 1)
 	expect.Error(t, err)
 
-	_, err = store.List(1, 0)
+	_, err = store.List(userID, 1, 0)
 	expect.Error(t, err)
 
-	datasources, err := store.List(1, 10)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedDatasources, datasources)
-
-	datasources, err = store.List(2, 3)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedDatasources[3:6], datasources)
-
-	datasources, err = store.List(4, 3)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedDatasources[9:10], datasources)
-
-	datasources, err = store.List(10, 3)
+	// when accessed by non owning user
+	datasources, err := store.List(uuid.New().String(), 1, 10)
 	expect.Ok(t, err)
 	expect.Equal(t, []*querycache.Datasource{}, datasources)
 
-	datasources, err = store.List(1, 30)
+	datasources, err = store.List(userID, 1, 10)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedDatasources, datasources)
+
+	datasources, err = store.List(userID, 2, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedDatasources[3:6], datasources)
+
+	datasources, err = store.List(userID, 4, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedDatasources[9:10], datasources)
+
+	datasources, err = store.List(userID, 10, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, []*querycache.Datasource{}, datasources)
+
+	datasources, err = store.List(userID, 1, 30)
 	expect.Ok(t, err)
 	expect.Equal(t, expectedDatasources, datasources)
 }

--- a/querycache/datasource_store_test.go
+++ b/querycache/datasource_store_test.go
@@ -37,7 +37,7 @@ func testDatasourceCreate(t *testing.T, store querycache.DatasourceStore, id str
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
-	datasource, err = store.Get(id)
+	datasource, err = store.Get(userID, id)
 	expect.Ok(t, err)
 
 	expect.Equal(t, expected, datasource)
@@ -91,7 +91,7 @@ func testDatasourceGet(t *testing.T, store querycache.DatasourceStore, id string
 	})
 	expect.Ok(t, err)
 
-	datasource, err := store.Get(id)
+	datasource, err := store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 }
@@ -127,7 +127,7 @@ func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id str
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
-	datasource, err = store.Get(id)
+	datasource, err = store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
@@ -141,7 +141,7 @@ func testDatasourceUpdate(t *testing.T, store querycache.DatasourceStore, id str
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 
-	datasource, err = store.Get(id)
+	datasource, err = store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, datasource)
 }

--- a/querycache/executor.go
+++ b/querycache/executor.go
@@ -109,7 +109,7 @@ func updateCache(cache *CachedExecutor, query *Query, result string) {
 		return
 	}
 
-	cache.Store.Update(query.ID, &UpdateQuery{LastRefresh: cache.Clock.Now()})
+	cache.Store.Update(query.UserID, query.ID, &UpdateQuery{LastRefresh: cache.Clock.Now()})
 }
 
 // NewCachedExecutor sets up a new CachedExecutor

--- a/querycache/helpers_test.go
+++ b/querycache/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/cga1123/bissy-api/auth"
 	"github.com/cga1123/bissy-api/querycache"
 	"github.com/cga1123/bissy-api/utils"
 	"github.com/google/uuid"
@@ -28,6 +29,10 @@ func newTestDatasourceStore(db *hnysqlx.DB, now time.Time, id string) *querycach
 		&utils.TestIDGenerator{ID: id})
 }
 
+func testClaims() *auth.Claims {
+	return &auth.Claims{UserID: uuid.New().String()}
+}
+
 func testConfig(db *hnysqlx.DB) (time.Time, string, *querycache.Config) {
 	now := time.Now().Truncate(time.Millisecond)
 	id := uuid.New().String()
@@ -38,10 +43,11 @@ func testConfig(db *hnysqlx.DB) (time.Time, string, *querycache.Config) {
 		Executor:        &querycache.TestExecutor{}}
 }
 
-func testHandler(c *querycache.Config, r *http.Request) *httptest.ResponseRecorder {
+func testHandler(claims *auth.Claims, c *querycache.Config, r *http.Request) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
 
 	router := mux.NewRouter()
+	router.Use(auth.TestMiddleware(claims))
 	c.SetupHandlers(router)
 
 	router.ServeHTTP(recorder, r)

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -85,21 +85,7 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 		return err
 	}
 
-	datasource, err := c.DatasourceStore.Get(query.DatasourceID)
-	if err != nil {
-		return err
-	}
-
-	executor, err := datasource.NewExecutor()
-	if err != nil {
-		return err
-	}
-
-	if c.Cache != nil {
-		executor = NewCachedExecutor(c.Cache, c.QueryStore, c.Clock, executor)
-	}
-
-	result, err := executor.Execute(query)
+	result, err := c.executeQuery(query)
 	if err != nil {
 		return err
 	}
@@ -107,4 +93,22 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 	_, err = fmt.Fprintf(w, result)
 
 	return err
+}
+
+func (c *Config) executeQuery(query *Query) (string, error) {
+	datasource, err := c.DatasourceStore.Get(query.DatasourceID)
+	if err != nil {
+		return "", err
+	}
+
+	executor, err := datasource.NewExecutor()
+	if err != nil {
+		return "", err
+	}
+
+	if c.Cache != nil {
+		executor = NewCachedExecutor(c.Cache, c.QueryStore, c.Clock, executor)
+	}
+
+	return executor.Execute(query)
 }

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -54,7 +54,7 @@ func (c *Config) queryGet(claims *auth.Claims, id string, w http.ResponseWriter,
 }
 
 func (c *Config) queryDelete(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
-	query, err := c.QueryStore.Delete(id)
+	query, err := c.QueryStore.Delete(claims.UserID, id)
 	if err != nil {
 		return err
 	}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cga1123/bissy-api/auth"
 	"github.com/cga1123/bissy-api/handlerutils"
 	"github.com/cga1123/bissy-api/utils"
 )
 
-func (c *Config) queriesList(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queriesList(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -25,7 +26,7 @@ func (c *Config) queriesList(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(queries)
 }
 
-func (c *Config) queriesCreate(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queriesCreate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	var createQuery CreateQuery
@@ -49,7 +50,7 @@ func (c *Config) queriesCreate(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (c *Config) queryGet(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queryGet(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -67,7 +68,7 @@ func (c *Config) queryGet(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryDelete(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queryDelete(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -85,7 +86,7 @@ func (c *Config) queryDelete(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryUpdate(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queryUpdate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
 
 	params := handlerutils.Params(r)
@@ -109,7 +110,7 @@ func (c *Config) queryUpdate(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryResult(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queryResult(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeCSV)
 
 	params := handlerutils.Params(r)

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -85,8 +85,7 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 		return err
 	}
 
-	// TODO: no need to pass claims one Query has a UserID!
-	result, err := c.executeQuery(claims.UserID, query)
+	result, err := c.executeQuery(query)
 	if err != nil {
 		return err
 	}
@@ -96,8 +95,8 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 	return err
 }
 
-func (c *Config) executeQuery(userID string, query *Query) (string, error) {
-	datasource, err := c.DatasourceStore.Get(userID, query.DatasourceID)
+func (c *Config) executeQuery(query *Query) (string, error) {
+	datasource, err := c.DatasourceStore.Get(query.UserID, query.DatasourceID)
 	if err != nil {
 		return "", err
 	}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -69,7 +69,7 @@ func (c *Config) queryUpdate(claims *auth.Claims, id string, w http.ResponseWrit
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	query, err := c.QueryStore.Update(id, &updateQuery)
+	query, err := c.QueryStore.Update(claims.UserID, id, &updateQuery)
 	if err != nil {
 		return err
 	}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -45,7 +45,7 @@ func (c *Config) queriesCreate(claims *auth.Claims, w http.ResponseWriter, r *ht
 }
 
 func (c *Config) queryGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
-	query, err := c.QueryStore.Get(id)
+	query, err := c.QueryStore.Get(claims.UserID, id)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (c *Config) queryUpdate(claims *auth.Claims, id string, w http.ResponseWrit
 func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeCSV)
 
-	query, err := c.QueryStore.Get(id)
+	query, err := c.QueryStore.Get(claims.UserID, id)
 	if err != nil {
 		return err
 	}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -17,7 +17,7 @@ func (c *Config) queriesList(claims *auth.Claims, w http.ResponseWriter, r *http
 	page := params.MaybeInt("page", 1)
 	per := params.MaybeInt("per", 25)
 
-	queries, err := c.QueryStore.List(page, per)
+	queries, err := c.QueryStore.List(claims.UserID, page, per)
 	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: err, Status: http.StatusInternalServerError}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -50,16 +50,7 @@ func (c *Config) queriesCreate(claims *auth.Claims, w http.ResponseWriter, r *ht
 	return nil
 }
 
-func (c *Config) queryGet(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) queryGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	query, err := c.QueryStore.Get(id)
 	if err != nil {
 		return err
@@ -68,16 +59,7 @@ func (c *Config) queryGet(claims *auth.Claims, w http.ResponseWriter, r *http.Re
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryDelete(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) queryDelete(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	query, err := c.QueryStore.Delete(id)
 	if err != nil {
 		return err
@@ -86,16 +68,7 @@ func (c *Config) queryDelete(claims *auth.Claims, w http.ResponseWriter, r *http
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryUpdate(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
-	handlerutils.ContentType(w, handlerutils.ContentTypeJSON)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
-
+func (c *Config) queryUpdate(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	var updateQuery UpdateQuery
 	if err := utils.ParseJSONBody(r.Body, &updateQuery); err != nil {
 		return &handlerutils.HandlerError{
@@ -110,15 +83,8 @@ func (c *Config) queryUpdate(claims *auth.Claims, w http.ResponseWriter, r *http
 	return json.NewEncoder(w).Encode(query)
 }
 
-func (c *Config) queryResult(claims *auth.Claims, w http.ResponseWriter, r *http.Request) error {
+func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {
 	handlerutils.ContentType(w, handlerutils.ContentTypeCSV)
-
-	params := handlerutils.Params(r)
-	id, ok := params.Get("id")
-	if !ok {
-		return &handlerutils.HandlerError{
-			Err: fmt.Errorf("id not set"), Status: http.StatusBadRequest}
-	}
 
 	query, err := c.QueryStore.Get(id)
 	if err != nil {

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -41,13 +41,7 @@ func (c *Config) queriesCreate(claims *auth.Claims, w http.ResponseWriter, r *ht
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	err = json.NewEncoder(w).Encode(query)
-	if err != nil {
-		return &handlerutils.HandlerError{
-			Err: err, Status: http.StatusInternalServerError}
-	}
-
-	return nil
+	return json.NewEncoder(w).Encode(query)
 }
 
 func (c *Config) queryGet(claims *auth.Claims, id string, w http.ResponseWriter, r *http.Request) error {

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -85,7 +85,8 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 		return err
 	}
 
-	result, err := c.executeQuery(query)
+	// TODO: no need to pass claims one Query has a UserID!
+	result, err := c.executeQuery(claims.UserID, query)
 	if err != nil {
 		return err
 	}
@@ -95,8 +96,8 @@ func (c *Config) queryResult(claims *auth.Claims, id string, w http.ResponseWrit
 	return err
 }
 
-func (c *Config) executeQuery(query *Query) (string, error) {
-	datasource, err := c.DatasourceStore.Get(query.DatasourceID)
+func (c *Config) executeQuery(userID string, query *Query) (string, error) {
+	datasource, err := c.DatasourceStore.Get(userID, query.DatasourceID)
 	if err != nil {
 		return "", err
 	}

--- a/querycache/query_handlers.go
+++ b/querycache/query_handlers.go
@@ -35,7 +35,7 @@ func (c *Config) queriesCreate(claims *auth.Claims, w http.ResponseWriter, r *ht
 			Err: err, Status: http.StatusUnprocessableEntity}
 	}
 
-	query, err := c.QueryStore.Create(&createQuery)
+	query, err := c.QueryStore.Create(claims.UserID, &createQuery)
 	if err != nil {
 		return &handlerutils.HandlerError{
 			Err: err, Status: http.StatusUnprocessableEntity}

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -37,7 +37,8 @@ func TestQueryCreate(t *testing.T) {
 	request, err := http.NewRequest("POST", "/queries", json)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 
 	actual, err := config.QueryStore.Get(id)
@@ -66,7 +67,8 @@ func TestQueryCreateBadRequest(t *testing.T) {
 	expect.Ok(t, err)
 
 	_, _, config := testConfig(db)
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 
 	expecthttp.Status(t, http.StatusUnprocessableEntity, response)
 }
@@ -93,7 +95,8 @@ func TestQueryGet(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+id, nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, query, response.Body)
@@ -112,7 +115,8 @@ func TestQueryGetNotFound(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+uuid.New().String(), nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Status(t, http.StatusInternalServerError, response)
 }
 
@@ -136,7 +140,8 @@ func TestQueryDelete(t *testing.T) {
 	request, err := http.NewRequest("DELETE", "/queries/"+id, nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, query, response.Body)
@@ -159,7 +164,8 @@ func TestQueryDeleteNotFound(t *testing.T) {
 	request, err := http.NewRequest("DELETE", "/queries/"+uuid.New().String(), nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Status(t, http.StatusInternalServerError, response)
 }
 
@@ -198,7 +204,8 @@ func TestQueryUpdate(t *testing.T) {
 	query.Lifetime = querycache.Duration(time.Hour + time.Minute)
 	query.LastRefresh = oneHourAgo
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, query, response.Body)
@@ -225,7 +232,8 @@ func TestQueryUpdateNotFound(t *testing.T) {
 	request, err := http.NewRequest("PATCH", "/queries/"+id, json)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Status(t, http.StatusInternalServerError, response)
 }
 
@@ -257,7 +265,8 @@ func TestQueryList(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries", nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, queries[:25], response.Body)
@@ -266,7 +275,7 @@ func TestQueryList(t *testing.T) {
 	request, err = http.NewRequest("GET", "/queries?page=2&per=5", nil)
 	expect.Ok(t, err)
 
-	response = testHandler(config, request)
+	response = testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, queries[5:10], response.Body)
@@ -295,7 +304,8 @@ func TestQueryResult(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+query.ID+"/result", nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeCSV, response)
 	expecthttp.StringBody(t, "Got: SELECT * FROM users", response)
@@ -325,7 +335,8 @@ func TestQueryResultPostgres(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+query.ID+"/result", nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeCSV, response)
 	expecthttp.StringBody(t, "?column?\n1\n", response)

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -147,7 +147,7 @@ func TestQueryDelete(t *testing.T) {
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, query, response.Body)
 
-	queries, err := config.QueryStore.List(1, 1)
+	queries, err := config.QueryStore.List(claims.UserID, 1, 1)
 	expect.Ok(t, err)
 	expect.Equal(t, []*querycache.Query{}, queries)
 }

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -299,8 +299,9 @@ func TestQueryResult(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, clock, generator),
 	}
 
-	userID := uuid.New().String()
-	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{Type: "test", Name: "Test"})
+	claims := testClaims()
+	datasource, err := config.DatasourceStore.Create(claims.UserID,
+		&querycache.CreateDatasource{Type: "test", Name: "Test"})
 	expect.Ok(t, err)
 
 	query, err := config.QueryStore.Create(&querycache.CreateQuery{
@@ -310,7 +311,6 @@ func TestQueryResult(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+query.ID+"/result", nil)
 	expect.Ok(t, err)
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeCSV, response)
@@ -330,8 +330,8 @@ func TestQueryResultPostgres(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, clock, generator),
 	}
 
-	userID := uuid.New().String()
-	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{
+	claims := testClaims()
+	datasource, err := config.DatasourceStore.Create(claims.UserID, &querycache.CreateDatasource{
 		Type: "postgres", Name: "PG Test", Options: os.Getenv("DATABASE_URL")})
 	expect.Ok(t, err)
 
@@ -342,7 +342,6 @@ func TestQueryResultPostgres(t *testing.T) {
 	request, err := http.NewRequest("GET", "/queries/"+query.ID+"/result", nil)
 	expect.Ok(t, err)
 
-	claims := testClaims()
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 	expecthttp.ContentType(t, handlerutils.ContentTypeCSV, response)

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -44,6 +44,7 @@ func TestQueryCreate(t *testing.T) {
 	actual, err := config.QueryStore.Get(claims.UserID, id)
 	expected := &querycache.Query{
 		ID:           id,
+		UserID:       claims.UserID,
 		Lifetime:     querycache.Duration(time.Hour + time.Minute),
 		Query:        "SELECT 1;",
 		DatasourceID: datasource.ID,

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -24,7 +24,8 @@ func TestQueryCreate(t *testing.T) {
 	defer teardown()
 
 	now, id, config := testConfig(db)
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{Type: "test", Name: "Test"})
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{Type: "test", Name: "Test"})
 	expect.Ok(t, err)
 
 	json, err := jsonBody(map[string]string{
@@ -81,7 +82,8 @@ func TestQueryGet(t *testing.T) {
 
 	_, id, config := testConfig(db)
 
-	datasource, err := config.DatasourceStore.Create(
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID,
 		&querycache.CreateDatasource{Type: "test", Name: "Test"})
 
 	expect.Ok(t, err)
@@ -127,7 +129,8 @@ func TestQueryDelete(t *testing.T) {
 	defer teardown()
 
 	_, id, config := testConfig(db)
-	datasource, err := config.DatasourceStore.Create(
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID,
 		&querycache.CreateDatasource{Type: "test", Name: "Test"})
 
 	query, err := config.QueryStore.Create(&querycache.CreateQuery{
@@ -182,7 +185,8 @@ func TestQueryUpdate(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, &utils.RealClock{}, &utils.UUIDGenerator{}),
 		Executor:        &querycache.TestExecutor{}}
 
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{Type: "test", Name: "Test"})
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{Type: "test", Name: "Test"})
 	expect.Ok(t, err)
 
 	query, err := config.QueryStore.Create(&querycache.CreateQuery{
@@ -249,7 +253,8 @@ func TestQueryList(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, &utils.RealClock{}, &utils.UUIDGenerator{}),
 	}
 
-	datasource, err := config.DatasourceStore.Create(
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID,
 		&querycache.CreateDatasource{Type: "test", Name: "Test"})
 	expect.Ok(t, err)
 
@@ -294,7 +299,8 @@ func TestQueryResult(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, clock, generator),
 	}
 
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{Type: "test", Name: "Test"})
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{Type: "test", Name: "Test"})
 	expect.Ok(t, err)
 
 	query, err := config.QueryStore.Create(&querycache.CreateQuery{
@@ -324,7 +330,8 @@ func TestQueryResultPostgres(t *testing.T) {
 		DatasourceStore: querycache.NewSQLDatasourceStore(db, clock, generator),
 	}
 
-	datasource, err := config.DatasourceStore.Create(&querycache.CreateDatasource{
+	userID := uuid.New().String()
+	datasource, err := config.DatasourceStore.Create(userID, &querycache.CreateDatasource{
 		Type: "postgres", Name: "PG Test", Options: os.Getenv("DATABASE_URL")})
 	expect.Ok(t, err)
 

--- a/querycache/query_handlers_test.go
+++ b/querycache/query_handlers_test.go
@@ -42,7 +42,7 @@ func TestQueryCreate(t *testing.T) {
 	response := testHandler(claims, config, request)
 	expecthttp.Ok(t, response)
 
-	actual, err := config.QueryStore.Get(id)
+	actual, err := config.QueryStore.Get(claims.UserID, id)
 	expected := &querycache.Query{
 		ID:           id,
 		Lifetime:     querycache.Duration(time.Hour + time.Minute),
@@ -214,7 +214,7 @@ func TestQueryUpdate(t *testing.T) {
 	expecthttp.ContentType(t, handlerutils.ContentTypeJSON, response)
 	expecthttp.JSONBody(t, query, response.Body)
 
-	query, err = config.QueryStore.Get(id)
+	query, err = config.QueryStore.Get(claims.UserID, id)
 	expect.Ok(t, err)
 
 	expect.Equal(t, querycache.Duration(time.Hour+time.Minute), query.Lifetime)

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -34,7 +34,7 @@ func (s *SQLQueryStore) Get(userID, id string) (*Query, error) {
 }
 
 // Create creates and persist to memory a Query from a CreateQuery struct
-func (s *SQLQueryStore) Create(ca *CreateQuery) (*Query, error) {
+func (s *SQLQueryStore) Create(userID string, ca *CreateQuery) (*Query, error) {
 	now := s.clock.Now()
 	id := s.idGenerator.Generate()
 

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -24,9 +24,9 @@ func NewSQLQueryStore(db *hnysqlx.DB, clock utils.Clock, generator utils.IDGener
 func (s *SQLQueryStore) Get(userID, id string) (*Query, error) {
 	var query Query
 
-	queryStr := "SELECT * FROM querycache_queries WHERE id = $1"
+	queryStr := "SELECT * FROM querycache_queries WHERE id = $1 AND user_id = $2"
 
-	if err := s.db.Get(&query, queryStr, id); err != nil {
+	if err := s.db.Get(&query, queryStr, id, userID); err != nil {
 		return nil, err
 	}
 

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -21,7 +21,7 @@ func NewSQLQueryStore(db *hnysqlx.DB, clock utils.Clock, generator utils.IDGener
 }
 
 // Get returns the Query with associated id from the store
-func (s *SQLQueryStore) Get(id string) (*Query, error) {
+func (s *SQLQueryStore) Get(userID, id string) (*Query, error) {
 	var query Query
 
 	queryStr := "SELECT * FROM querycache_queries WHERE id = $1"

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -52,12 +52,12 @@ func (s *SQLQueryStore) Create(userID string, ca *CreateQuery) (*Query, error) {
 }
 
 // Delete removes the Query with associated id from the store
-func (s *SQLQueryStore) Delete(id string) (*Query, error) {
+func (s *SQLQueryStore) Delete(userID, id string) (*Query, error) {
 	var query Query
 
-	queryStr := "DELETE FROM querycache_queries WHERE id = $1 RETURNING *"
+	queryStr := "DELETE FROM querycache_queries WHERE id = $1 AND user_id = $2 RETURNING *"
 
-	if err := s.db.Get(&query, queryStr, id); err != nil {
+	if err := s.db.Get(&query, queryStr, id, userID); err != nil {
 		return nil, err
 	}
 

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -94,7 +94,7 @@ func (s *SQLQueryStore) Update(userID, id string, uq *UpdateQuery) (*Query, erro
 }
 
 // List returns the requests Queries from the Store, ordered by createdAt
-func (s *SQLQueryStore) List(page, per int) ([]*Query, error) {
+func (s *SQLQueryStore) List(userID string, page, per int) ([]*Query, error) {
 	if page < 1 || per < 1 {
 		return nil,
 			fmt.Errorf("page and per must be greater than 0 (page %v) (per %v)",
@@ -103,8 +103,14 @@ func (s *SQLQueryStore) List(page, per int) ([]*Query, error) {
 
 	queries := []*Query{}
 
-	queryStr := `SELECT * FROM querycache_queries ORDER BY created_at OFFSET $1 LIMIT $2`
-	if err := s.db.Select(&queries, queryStr, (page-1)*per, per); err != nil {
+	queryStr := `
+		SELECT *
+		FROM querycache_queries
+		WHERE user_id = $1
+		ORDER BY created_at
+		OFFSET $2
+		LIMIT $3`
+	if err := s.db.Select(&queries, queryStr, userID, (page-1)*per, per); err != nil {
 		return nil, err
 	}
 

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -39,12 +39,12 @@ func (s *SQLQueryStore) Create(userID string, ca *CreateQuery) (*Query, error) {
 	id := s.idGenerator.Generate()
 
 	queryStr := `
-		INSERT INTO querycache_queries (id, query, lifetime, datasource_id, created_at, updated_at, last_refresh)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO querycache_queries (id, user_id, query, lifetime, datasource_id, created_at, updated_at, last_refresh)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING *`
 
 	var query Query
-	if err := s.db.Get(&query, queryStr, id, ca.Query, ca.Lifetime, ca.DatasourceID, now, now, now); err != nil {
+	if err := s.db.Get(&query, queryStr, id, userID, ca.Query, ca.Lifetime, ca.DatasourceID, now, now, now); err != nil {
 		return nil, err
 	}
 

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -73,7 +73,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // QueryStore describes a generic Store for Queries
 type QueryStore interface {
-	Get(string) (*Query, error)
+	Get(string, string) (*Query, error)
 	Create(*CreateQuery) (*Query, error)
 	List(page int, per int) ([]*Query, error)
 	Delete(string) (*Query, error)

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -78,5 +78,5 @@ type QueryStore interface {
 	Create(string, *CreateQuery) (*Query, error)
 	List(page int, per int) ([]*Query, error)
 	Delete(string) (*Query, error)
-	Update(string, *UpdateQuery) (*Query, error)
+	Update(string, string, *UpdateQuery) (*Query, error)
 }

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -10,6 +10,7 @@ import (
 // a given Lifetime value
 type Query struct {
 	ID           string    `json:"id"`
+	UserID       string    `json:"userId" db:"user_id"`
 	Query        string    `json:"query"`
 	DatasourceID string    `json:"datasourceId" db:"datasource_id"`
 	Lifetime     Duration  `json:"lifetime"`

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -76,7 +76,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 type QueryStore interface {
 	Get(string, string) (*Query, error)
 	Create(string, *CreateQuery) (*Query, error)
-	List(page int, per int) ([]*Query, error)
+	List(string, int, int) ([]*Query, error)
 	Delete(string, string) (*Query, error)
 	Update(string, string, *UpdateQuery) (*Query, error)
 }

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -77,6 +77,6 @@ type QueryStore interface {
 	Get(string, string) (*Query, error)
 	Create(string, *CreateQuery) (*Query, error)
 	List(page int, per int) ([]*Query, error)
-	Delete(string) (*Query, error)
+	Delete(string, string) (*Query, error)
 	Update(string, string, *UpdateQuery) (*Query, error)
 }

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -74,7 +74,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 // QueryStore describes a generic Store for Queries
 type QueryStore interface {
 	Get(string, string) (*Query, error)
-	Create(*CreateQuery) (*Query, error)
+	Create(string, *CreateQuery) (*Query, error)
 	List(page int, per int) ([]*Query, error)
 	Delete(string) (*Query, error)
 	Update(string, *UpdateQuery) (*Query, error)

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -179,10 +179,18 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 		LastRefresh:  now,
 	}
 
-	_, err = store.Create(userID, &createQuery)
+	expectedQuery, err := store.Create(userID, &createQuery)
 	expect.Ok(t, err)
 
-	query, err := store.Delete(id)
+	_, err = store.Delete(uuid.New().String(), id)
+	expect.Error(t, err)
+	expect.True(t, err == sql.ErrNoRows)
+
+	query, err := store.Get(userID, id)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedQuery, query)
+
+	query, err = store.Delete(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, *query)
 
@@ -191,8 +199,9 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 
 	expect.Equal(t, []*querycache.Query{}, queries)
 
-	_, err = store.Delete(id)
+	_, err = store.Delete(userID, id)
 	expect.Error(t, err)
+
 }
 
 func testQueryUpdate(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore, id string, now time.Time) {

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -39,7 +39,8 @@ func TestFresh(t *testing.T) {
 }
 
 func testQueryCreate(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore, id string, now time.Time) {
-	datasource, err := datasourceStore.Create(&querycache.CreateDatasource{})
+	userID := uuid.New().String()
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
 	expect.Ok(t, err)
 
 	createQuery := querycache.CreateQuery{
@@ -69,7 +70,8 @@ func testQueryCreate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 }
 
 func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore, id string, now time.Time) {
-	datasource, err := datasourceStore.Create(&querycache.CreateDatasource{})
+	userID := uuid.New().String()
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
 	expect.Ok(t, err)
 
 	createQuery := querycache.CreateQuery{
@@ -102,7 +104,8 @@ func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, stor
 }
 
 func testQueryList(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore) {
-	datasource, err := datasourceStore.Create(&querycache.CreateDatasource{})
+	userID := uuid.New().String()
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
 	expect.Ok(t, err)
 
 	expectedQueries := []*querycache.Query{}
@@ -147,7 +150,8 @@ func testQueryList(t *testing.T, datasourceStore querycache.DatasourceStore, sto
 }
 
 func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore, id string, now time.Time) {
-	datasource, err := datasourceStore.Create(&querycache.CreateDatasource{})
+	userID := uuid.New().String()
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
 	expect.Ok(t, err)
 
 	createQuery := querycache.CreateQuery{
@@ -183,7 +187,8 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 }
 
 func testQueryUpdate(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore, id string, now time.Time) {
-	datasource, err := datasourceStore.Create(&querycache.CreateDatasource{})
+	userID := uuid.New().String()
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
 	expect.Ok(t, err)
 
 	createQuery := querycache.CreateQuery{

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -130,29 +130,34 @@ func testQueryList(t *testing.T, datasourceStore querycache.DatasourceStore, sto
 		expectedQueries = append(expectedQueries, query)
 	}
 
-	_, err = store.List(0, 1)
+	_, err = store.List(userID, 0, 1)
 	expect.Error(t, err)
 
-	_, err = store.List(1, 0)
+	_, err = store.List(userID, 1, 0)
 	expect.Error(t, err)
 
-	queries, err := store.List(1, 10)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedQueries, queries)
-
-	queries, err = store.List(2, 3)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedQueries[3:6], queries)
-
-	queries, err = store.List(4, 3)
-	expect.Ok(t, err)
-	expect.Equal(t, expectedQueries[9:10], queries)
-
-	queries, err = store.List(10, 3)
+	// with another user
+	queries, err := store.List(uuid.New().String(), 1, 10)
 	expect.Ok(t, err)
 	expect.Equal(t, []*querycache.Query{}, queries)
 
-	queries, err = store.List(1, 30)
+	queries, err = store.List(userID, 1, 10)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedQueries, queries)
+
+	queries, err = store.List(userID, 2, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedQueries[3:6], queries)
+
+	queries, err = store.List(userID, 4, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, expectedQueries[9:10], queries)
+
+	queries, err = store.List(userID, 10, 3)
+	expect.Ok(t, err)
+	expect.Equal(t, []*querycache.Query{}, queries)
+
+	queries, err = store.List(userID, 1, 30)
 	expect.Ok(t, err)
 	expect.Equal(t, expectedQueries, queries)
 }
@@ -194,7 +199,7 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 	expect.Ok(t, err)
 	expect.Equal(t, expected, *query)
 
-	queries, err := store.List(1, 1)
+	queries, err := store.List(userID, 1, 1)
 	expect.Ok(t, err)
 
 	expect.Equal(t, []*querycache.Query{}, queries)

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -1,6 +1,7 @@
 package querycache_test
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -103,6 +104,11 @@ func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, stor
 	// when id is not found
 	_, err = store.Get(userID, uuid.New().String())
 	expect.Error(t, err)
+
+	// when a different user
+	_, err = store.Get(uuid.New().String(), id)
+	expect.Error(t, err)
+	expect.True(t, err == sql.ErrNoRows)
 }
 
 func testQueryList(t *testing.T, datasourceStore querycache.DatasourceStore, store querycache.QueryStore) {

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -64,7 +64,7 @@ func testQueryCreate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 	expect.Ok(t, err)
 	expect.Equal(t, expected, query)
 
-	query, err = store.Get(id)
+	query, err = store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, query)
 }
@@ -94,12 +94,12 @@ func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, stor
 	expect.Ok(t, err)
 
 	// when id is found
-	query, err := store.Get(id)
+	query, err := store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, *query)
 
 	// when id is not found
-	_, err = store.Get(uuid.New().String())
+	_, err = store.Get(userID, uuid.New().String())
 	expect.Error(t, err)
 }
 
@@ -221,7 +221,7 @@ func testQueryUpdate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 	expect.Equal(t, expected, *query)
 
 	// Test persistence
-	query, err = store.Get(id)
+	query, err = store.Get(userID, id)
 	expect.Ok(t, err)
 	expect.Equal(t, expected, *query)
 

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -59,7 +59,7 @@ func testQueryCreate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 		LastRefresh:  now,
 	}
 
-	query, err := store.Create(&createQuery)
+	query, err := store.Create(userID, &createQuery)
 
 	expect.Ok(t, err)
 	expect.Equal(t, expected, query)
@@ -90,7 +90,7 @@ func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, stor
 		LastRefresh:  now,
 	}
 
-	_, err = store.Create(&createQuery)
+	_, err = store.Create(userID, &createQuery)
 	expect.Ok(t, err)
 
 	// when id is found
@@ -116,7 +116,7 @@ func testQueryList(t *testing.T, datasourceStore querycache.DatasourceStore, sto
 			Lifetime:     querycache.Duration(time.Duration(i) * time.Hour),
 			DatasourceID: datasource.ID,
 		}
-		query, err := store.Create(q)
+		query, err := store.Create(userID, q)
 		expect.Ok(t, err)
 
 		expectedQueries = append(expectedQueries, query)
@@ -170,7 +170,7 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 		LastRefresh:  now,
 	}
 
-	_, err = store.Create(&createQuery)
+	_, err = store.Create(userID, &createQuery)
 	expect.Ok(t, err)
 
 	query, err := store.Delete(id)
@@ -212,7 +212,7 @@ func testQueryUpdate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 		LastRefresh:  now,
 	}
 
-	_, err = store.Create(&createQuery)
+	_, err = store.Create(userID, &createQuery)
 	expect.Ok(t, err)
 
 	// Test returned query

--- a/querycache/query_store_test.go
+++ b/querycache/query_store_test.go
@@ -51,6 +51,7 @@ func testQueryCreate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 
 	expected := &querycache.Query{
 		ID:           id,
+		UserID:       userID,
 		Query:        "SELECT 1;",
 		DatasourceID: datasource.ID,
 		Lifetime:     3 * querycache.Duration(time.Hour),
@@ -82,6 +83,7 @@ func testQueryGet(t *testing.T, datasourceStore querycache.DatasourceStore, stor
 
 	expected := querycache.Query{
 		ID:           id,
+		UserID:       userID,
 		Query:        "SELECT 1;",
 		DatasourceID: datasource.ID,
 		Lifetime:     3 * querycache.Duration(time.Hour),
@@ -162,6 +164,7 @@ func testQueryDelete(t *testing.T, datasourceStore querycache.DatasourceStore, s
 
 	expected := querycache.Query{
 		ID:           id,
+		UserID:       userID,
 		Query:        "SELECT 1;",
 		DatasourceID: datasource.ID,
 		Lifetime:     3 * querycache.Duration(time.Hour),
@@ -204,6 +207,7 @@ func testQueryUpdate(t *testing.T, datasourceStore querycache.DatasourceStore, s
 
 	expected := querycache.Query{
 		ID:           id,
+		UserID:       userID,
 		Query:        "SELECT 1;",
 		DatasourceID: datasource.ID,
 		Lifetime:     newLifetime,

--- a/querycache/router.go
+++ b/querycache/router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cga1123/bissy-api/auth"
 	"github.com/cga1123/bissy-api/handlerutils"
 	"github.com/cga1123/bissy-api/utils"
 	"github.com/gorilla/mux"
@@ -18,52 +19,60 @@ type Config struct {
 	Clock           utils.Clock
 }
 
+func handler(next func(*auth.Claims, http.ResponseWriter, *http.Request) error) http.Handler {
+	return &handlerutils.Handler{
+		H: auth.BuildHandler(next),
+	}
+}
+
 // SetupHandlers mounts the querycache handlers onto the given mux
 func (c *Config) SetupHandlers(router *mux.Router) {
 	router.HandleFunc("/", c.home).Methods("GET")
 
+	// Queries
 	router.
-		Handle("/queries", &handlerutils.Handler{H: c.queriesList}).
+		Handle("/queries", handler(c.queriesList)).
 		Methods("GET")
 
 	router.
-		Handle("/queries", &handlerutils.Handler{H: c.queriesCreate}).
+		Handle("/queries", handler(c.queriesCreate)).
 		Methods("POST")
 
 	router.
-		Handle("/queries/{id}", &handlerutils.Handler{H: c.queryGet}).
+		Handle("/queries/{id}", handler(c.queryGet)).
 		Methods("GET")
 
 	router.
-		Handle("/queries/{id}", &handlerutils.Handler{H: c.queryDelete}).
+		Handle("/queries/{id}", handler(c.queryDelete)).
 		Methods("DELETE")
 
 	router.
-		Handle("/queries/{id}", &handlerutils.Handler{H: c.queryUpdate}).
+		Handle("/queries/{id}", handler(c.queryUpdate)).
 		Methods("PATCH")
 
 	router.
-		Handle("/queries/{id}/result", &handlerutils.Handler{H: c.queryResult}).
+		Handle("/queries/{id}/result", handler(c.queryResult)).
+		Methods("GET")
+
+	// Datasources
+	router.
+		Handle("/datasources", handler(c.datasourcesList)).
 		Methods("GET")
 
 	router.
-		Handle("/datasources", &handlerutils.Handler{H: c.datasourcesList}).
-		Methods("GET")
-
-	router.
-		Handle("/datasources", &handlerutils.Handler{H: c.datasourcesCreate}).
+		Handle("/datasources", handler(c.datasourcesCreate)).
 		Methods("POST")
 
 	router.
-		Handle("/datasources/{id}", &handlerutils.Handler{H: c.datasourceGet}).
+		Handle("/datasources/{id}", handler(c.datasourceGet)).
 		Methods("GET")
 
 	router.
-		Handle("/datasources/{id}", &handlerutils.Handler{H: c.datasourceDelete}).
+		Handle("/datasources/{id}", handler(c.datasourceDelete)).
 		Methods("DELETE")
 
 	router.
-		Handle("/datasources/{id}", &handlerutils.Handler{H: c.datasourceUpdate}).
+		Handle("/datasources/{id}", handler(c.datasourceUpdate)).
 		Methods("PATCH")
 }
 

--- a/querycache/router_test.go
+++ b/querycache/router_test.go
@@ -20,7 +20,8 @@ func TestHome(t *testing.T) {
 	request, err := http.NewRequest("GET", "/", nil)
 	expect.Ok(t, err)
 
-	response := testHandler(config, request)
+	claims := testClaims()
+	response := testHandler(claims, config, request)
 
 	expectedBody := "querycache: using cache, saving cash\n"
 


### PR DESCRIPTION
- Update handler signature to take a `Claims`
- Add user-specific store methods that take `UserID`
- Migrate usages
- Update behaviour to be user scopes

Closes #51