### PR TITLE
querycache: update caching logic

### DIFF
--- a/querycache/executor.go
+++ b/querycache/executor.go
@@ -59,14 +59,13 @@ func (cache *InMemoryCache) Set(query *Query, result string) error {
 // RedisCache is a redis-backed implementation of QueryCache
 type RedisCache struct {
 	Client *redis.Client
-	Prefix string
 }
 
 // Get returns the cached results for a given query
 func (cache *RedisCache) Get(query *Query) (string, bool) {
 	value, err := cache.Client.Get(
 		context.TODO(),
-		cache.Prefix+":"+query.ID,
+		"querycache:"+query.ID,
 	).Result()
 
 	return value, err == nil
@@ -76,7 +75,7 @@ func (cache *RedisCache) Get(query *Query) (string, bool) {
 func (cache *RedisCache) Set(query *Query, result string) error {
 	set := cache.Client.Set(
 		context.TODO(),
-		cache.Prefix+":"+query.ID,
+		"querycache:"+query.ID,
 		result,
 		time.Duration(query.Lifetime))
 
@@ -110,7 +109,7 @@ func updateCache(cache *CachedExecutor, query *Query, result string) {
 		return
 	}
 
-	cache.Store.Update(query.ID, &UpdateQuery{LastRefresh: time.Now()})
+	cache.Store.Update(query.ID, &UpdateQuery{LastRefresh: cache.Clock.Now()})
 }
 
 // NewCachedExecutor sets up a new CachedExecutor

--- a/querycache/executor_test.go
+++ b/querycache/executor_test.go
@@ -48,7 +48,6 @@ func TestCachedExecutorExecute(t *testing.T) {
 	query := &querycache.Query{
 		ID:          "1",
 		LastRefresh: now,
-		UpdatedAt:   now.Add(-time.Second),
 		Lifetime:    querycache.Duration(time.Hour),
 		Query:       "SELECT 1;"}
 
@@ -61,17 +60,10 @@ func TestCachedExecutorExecute(t *testing.T) {
 	expect.Ok(t, err)
 	expect.Equal(t, "Got: SELECT 1;", result)
 
-	// When updated after last refresh
-	query.UpdatedAt = query.LastRefresh.Add(time.Second)
-	query.Query = "SELECT 3;"
-	result, err = executor.Execute(query)
-	expect.Ok(t, err)
-	expect.Equal(t, "Got: SELECT 3;", result)
-
 	// When LastRefresh longer than Lifetime ago
 	result, err = executor.Execute(query)
 	expect.Ok(t, err)
-	expect.Equal(t, "Got: SELECT 3;", result)
+	expect.Equal(t, "Got: SELECT 1;", result)
 
 	query.LastRefresh = now.Add(-time.Duration(query.Lifetime)).Add(-time.Second)
 	query.Query = "SELECT 4;"

--- a/querycache/query_sql_store.go
+++ b/querycache/query_sql_store.go
@@ -70,11 +70,9 @@ func (s *SQLQueryStore) Update(id string, uq *UpdateQuery) (*Query, error) {
 
 	queryStr := `
 		UPDATE querycache_queries
-		SET query = COALESCE($2, query),
-				datasource_id = COALESCE($3, datasource_id),
-				lifetime = COALESCE($4, lifetime),
-				last_refresh = COALESCE($5, last_refresh),
-				updated_at = $6
+		SET lifetime = COALESCE($2, lifetime),
+				last_refresh = COALESCE($3, last_refresh),
+				updated_at = $4
 		WHERE id = $1
 		RETURNING *`
 
@@ -85,7 +83,8 @@ func (s *SQLQueryStore) Update(id string, uq *UpdateQuery) (*Query, error) {
 		lastRefresh = sql.NullTime{Time: uq.LastRefresh, Valid: true}
 	}
 
-	if err := s.db.Get(&query, queryStr, id, uq.Query, uq.DatasourceID, uq.Lifetime, lastRefresh, s.clock.Now()); err != nil {
+	err := s.db.Get(&query, queryStr, id, uq.Lifetime, lastRefresh, s.clock.Now())
+	if err != nil {
 		return nil, err
 	}
 

--- a/querycache/query_store.go
+++ b/querycache/query_store.go
@@ -23,9 +23,8 @@ type Query struct {
 func (query *Query) Fresh(now time.Time) bool {
 	timeSinceLastRefresh := now.Sub(query.LastRefresh)
 	refreshedRecently := Duration(timeSinceLastRefresh) < query.Lifetime
-	updatedRecently := query.UpdatedAt.After(query.LastRefresh)
 
-	return refreshedRecently && !updatedRecently
+	return refreshedRecently
 }
 
 // CreateQuery describes the required parameter to create a new Query
@@ -37,10 +36,8 @@ type CreateQuery struct {
 
 // UpdateQuery describes the paramater which may be updated on a Query
 type UpdateQuery struct {
-	Query        *string   `json:"query"`
-	DatasourceID *string   `json:"datasourceId"`
-	Lifetime     *Duration `json:"lifetime"`
-	LastRefresh  time.Time `json:"lastRefresh"`
+	Lifetime    *Duration `json:"lifetime"`
+	LastRefresh time.Time `json:"lastRefresh"`
 }
 
 // Duration is an alias to time.Duration to allow for defining JSON marshalling

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"testing"
@@ -173,4 +174,8 @@ func TestJSONBody(t *testing.T) {
 	err = utils.ParseJSONBody(ioutil.NopCloser(reader), &target)
 	expect.Ok(t, err)
 	expect.Equal(t, json, target)
+
+	// when passed junk
+	_, err = utils.JSONBody(math.Inf(1))
+	expect.Error(t, err)
 }


### PR DESCRIPTION
Updates caching logic to remove need to check UpdatedAt time. No longer
allow updates to Query or DatasourceID over API.

Simplifies things, removes extra code. Can have a cloning feature on UI if needs-be.

Fixes a bug in caching where Query would never be Fresh as UpdatedAt is updated when
setting LastRefresh.