### PR TITLE
auth: implement an API-key based authentication provider

### DIFF
--- a/auth/apikeyprovider/apikeyprovider.go
+++ b/auth/apikeyprovider/apikeyprovider.go
@@ -1,0 +1,37 @@
+package apikeyprovider
+
+import (
+	"net/http"
+
+	"github.com/cga1123/bissy-api/auth"
+	"github.com/cga1123/bissy-api/auth/apikey"
+)
+
+// HeaderKey is the HTTP Header name expected to be populated by this provider
+const HeaderKey = "x-bissy-apikey"
+
+// Config holds the configuration for providing api key based authentication
+// It implements the auth.Provider interface
+type Config struct {
+	store apikey.Store
+}
+
+// New configures a apikeyprovider backed with the given apikey.Store
+func New(store apikey.Store) *Config {
+	return &Config{store: store}
+}
+
+// Valid checks whether a given request is attempting apikey authentication
+func (c *Config) Valid(r *http.Request) bool {
+	return r.Header.Get(HeaderKey) != ""
+}
+
+// Authenticate attempts to authenticate a request
+func (c *Config) Authenticate(r *http.Request) (*auth.Claims, bool) {
+	key, err := c.store.GetByKey(r.Header.Get(HeaderKey))
+	if err != nil {
+		return nil, false
+	}
+
+	return &auth.Claims{UserID: key.UserID}, true
+}

--- a/auth/apikeyprovider/apikeyprovider_test.go
+++ b/auth/apikeyprovider/apikeyprovider_test.go
@@ -1,0 +1,109 @@
+package apikeyprovider_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/DATA-DOG/go-txdb"
+	"github.com/cga1123/bissy-api/auth"
+	"github.com/cga1123/bissy-api/auth/apikey"
+	"github.com/cga1123/bissy-api/auth/apikeyprovider"
+	"github.com/cga1123/bissy-api/utils"
+	"github.com/cga1123/bissy-api/utils/expect"
+	_ "github.com/lib/pq"
+)
+
+func init() {
+	url, ok := os.LookupEnv("DATABASE_URL")
+	if !ok {
+		log.Fatal("DATABASE_URL not set")
+	}
+
+	txdb.Register("pgx", "postgres", url)
+}
+
+func TestIsProvider(t *testing.T) {
+	t.Parallel()
+
+	db, teardown := utils.TestDB(t)
+	defer teardown()
+
+	store := apikey.NewSQLStore(db)
+	config := apikeyprovider.New(store)
+
+	// check we conform to Provider interface
+	// tests will fail to compile if not.
+	var _ auth.Provider = config
+}
+
+func TestValid(t *testing.T) {
+	t.Parallel()
+
+	db, teardown := utils.TestDB(t)
+	defer teardown()
+
+	store := apikey.NewSQLStore(db)
+	config := apikeyprovider.New(store)
+
+	// empty request
+	request, err := http.NewRequest("GET", "/", nil)
+	expect.Ok(t, err)
+
+	expect.False(t, config.Valid(request))
+
+	// request with header
+	request.Header.Add(apikeyprovider.HeaderKey, "token")
+
+	expect.True(t, config.Valid(request))
+}
+
+func unsuccessfulAuth(t *testing.T, c *apikeyprovider.Config, r *http.Request) {
+	t.Helper()
+
+	claims, ok := c.Authenticate(r)
+
+	expect.True(t, nil == claims)
+	expect.False(t, ok)
+}
+
+func TestAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	db, teardown := utils.TestDB(t)
+	defer teardown()
+
+	user, err := auth.NewSQLUserStore(db).Create(&auth.CreateUser{GithubID: "test", Name: "Test"})
+	expect.Ok(t, err)
+
+	store := apikey.NewSQLStore(db)
+	key, err := store.Create(user.ID, &apikey.Create{Name: "test key"})
+	expect.Ok(t, err)
+
+	config := apikeyprovider.New(store)
+
+	// empty request
+	request, err := http.NewRequest("GET", "/", nil)
+	expect.Ok(t, err)
+
+	unsuccessfulAuth(t, config, request)
+
+	// unknown key
+	request, err = http.NewRequest("GET", "/", nil)
+	expect.Ok(t, err)
+
+	request.Header.Add(apikeyprovider.HeaderKey, "an unknown key")
+
+	unsuccessfulAuth(t, config, request)
+
+	// known key
+	request, err = http.NewRequest("GET", "/", nil)
+	expect.Ok(t, err)
+
+	request.Header.Add(apikeyprovider.HeaderKey, key.Key)
+
+	claims, ok := config.Authenticate(request)
+	expect.True(t, ok)
+	expect.Equal(t, user.ID, claims.UserID)
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,7 +11,7 @@ import (
 
 // The Provider interface describes and authentication provider, it contains two
 // methods:
-// - Valid which checks whether the given request is attempting to authenticate with a give provider
+// - Valid which checks whether the given request is attempting to authenticate with a given provider
 // - Authenticate which attempts to authenticate the request
 type Provider interface {
 	Valid(*http.Request) bool

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/cga1123/bissy-api/auth"
+	"github.com/cga1123/bissy-api/auth/apikey"
+	"github.com/cga1123/bissy-api/auth/apikeyprovider"
 	"github.com/cga1123/bissy-api/auth/github"
 	"github.com/cga1123/bissy-api/auth/jwtprovider"
 	"github.com/cga1123/bissy-api/ping"
@@ -161,7 +163,8 @@ func main() {
 	redisClient := initRedis(env)
 	db := initDb(env)
 	jwtConfig := jwtprovider.New([]byte(env[jwtSigningKeyVar]))
-	authConfig := &auth.Auth{Providers: []auth.Provider{jwtConfig}}
+	apikeyConfig := apikeyprovider.New(apikey.NewSQLStore(db))
+	authConfig := &auth.Auth{Providers: []auth.Provider{jwtConfig, apikeyConfig}}
 	corsConfig := initCors(env[frontendOrigin])
 
 	router := mux.NewRouter()


### PR DESCRIPTION
Implement `apikeyprovider` satisfying the `auth.Provider` interface.

Allows for authenticating request via API keys 🎉 