### PR TITLE
querycache: sharelinks

### DIFF
--- a/querycache/sharelink_store.go
+++ b/querycache/sharelink_store.go
@@ -1,0 +1,20 @@
+package querycache
+
+import "time"
+
+// A Sharelink is used to expose the results of a specific query to the public
+// A Query may have many sharelinks, which can be individually managed
+type Sharelink struct {
+	ID        string    `json:"id" db:"id"`
+	QueryID   string    `json:"queryId" db:"query_id"`
+	UserID    string    `json:"userId" db:"user_id"`
+	CreatedAt time.Time `json:"createdAt" db:"created_at"`
+}
+
+// The SharelinkStore is used to manage the collection of Sharelinks
+type SharelinkStore interface {
+	Create(*Query) (*Sharelink, error)
+	ListForQuery(*Query) ([]*Sharelink, error)
+	ListForUser(string) ([]*Sharelink, error)
+	Get(string) (*Sharelink, error)
+}

--- a/querycache/sharelink_store_test.go
+++ b/querycache/sharelink_store_test.go
@@ -1,0 +1,40 @@
+package querycache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cga1123/bissy-api/querycache"
+	"github.com/cga1123/bissy-api/utils/expect"
+)
+
+func testSharelinkCreate(t *testing.T, query querycache.Query, store querycache.SharelinkStore, id string, now time.Time) {
+	datasource, err := datasourceStore.Create(userID, &querycache.CreateDatasource{})
+	expect.Ok(t, err)
+
+	createQuery := querycache.CreateQuery{
+		Query:        "SELECT 1;",
+		Lifetime:     3 * querycache.Duration(time.Hour),
+		DatasourceID: datasource.ID,
+	}
+
+	expected := &querycache.Query{
+		ID:           id,
+		UserID:       userID,
+		Query:        "SELECT 1;",
+		DatasourceID: datasource.ID,
+		Lifetime:     3 * querycache.Duration(time.Hour),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastRefresh:  now,
+	}
+
+	query, err := store.Create(userID, &createQuery)
+
+	expect.Ok(t, err)
+	expect.Equal(t, expected, query)
+
+	query, err = store.Get(userID, id)
+	expect.Ok(t, err)
+	expect.Equal(t, expected, query)
+}


### PR DESCRIPTION
Sharelinks allow for public access to `querycache.Exexutor.Execute(*Query)`